### PR TITLE
Fix master

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -105,8 +105,7 @@ EventSource Protocol
 Requirements
 ------------
 
-* Python_ 3.3+
-* asyncio_ or Python_ 3.4+
+* Python_ 3.4+
 * aiohttp_ 1.1.0+
 
 

--- a/README.rst
+++ b/README.rst
@@ -107,7 +107,7 @@ Requirements
 
 * Python_ 3.3+
 * asyncio_ or Python_ 3.4+
-* aiohttp_
+* aiohttp_ 1.1.0+
 
 
 License

--- a/aiohttp_sse/__init__.py
+++ b/aiohttp_sse/__init__.py
@@ -4,7 +4,7 @@ from aiohttp.protocol import Response as ResponseImpl
 from aiohttp.web import StreamResponse
 from aiohttp.web import HTTPMethodNotAllowed
 
-__version__ = '0.0.3a0'
+__version__ = '1.0.0a0'
 __all__ = ['EventSourceResponse']
 
 

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ def read_version():
             raise RuntimeError(msg)
 
 
-install_requires = ['aiohttp>=0.14']
+install_requires = ['aiohttp>=1.1.0']
 
 
 setup(name='aiohttp-sse',

--- a/tests/test_sse.py
+++ b/tests/test_sse.py
@@ -4,6 +4,7 @@ import aiohttp
 import pytest
 from aiohttp import web
 from aiohttp_sse import EventSourceResponse
+from yarl import URL
 
 
 @pytest.mark.asyncio(forbid_global_loop=True)
@@ -28,7 +29,7 @@ def test_func(event_loop, unused_tcp_port):
     handler = app.make_handler()
     srv = yield from event_loop.create_server(
         handler, '127.0.0.1', unused_tcp_port)
-    url = "http://127.0.0.1:{}/".format(unused_tcp_port)
+    url = URL("http://127.0.0.1:{}/".format(unused_tcp_port))
 
     resp = yield from aiohttp.request('GET', url, loop=event_loop)
     assert 200 == resp.status
@@ -75,7 +76,7 @@ def test_wait_stop_streaming(event_loop, unused_tcp_port):
     handler = app.make_handler()
     srv = yield from loop.create_server(
         handler, '127.0.0.1', unused_tcp_port)
-    url = "http://127.0.0.1:{}/".format(unused_tcp_port)
+    url = URL("http://127.0.0.1:{}/".format(unused_tcp_port))
 
     resp_task = asyncio.async(
         aiohttp.request('GET', url, loop=event_loop),
@@ -117,7 +118,7 @@ def test_retry(event_loop, unused_tcp_port):
     handler = app.make_handler()
     srv = yield from event_loop.create_server(
         handler, '127.0.0.1', unused_tcp_port)
-    url = "http://127.0.0.1:{}/".format(unused_tcp_port)
+    url = URL("http://127.0.0.1:{}/".format(unused_tcp_port))
 
     resp = yield from aiohttp.request('GET', url, loop=event_loop)
     assert 200 == resp.status
@@ -185,7 +186,7 @@ def test_ping(event_loop, unused_tcp_port):
     handler = app.make_handler()
     srv = yield from event_loop.create_server(
         handler, '127.0.0.1', unused_tcp_port)
-    url = "http://127.0.0.1:{}/".format(unused_tcp_port)
+    url = URL("http://127.0.0.1:{}/".format(unused_tcp_port))
 
     resp_task = asyncio.async(
         aiohttp.request('GET', url, loop=event_loop),


### PR DESCRIPTION
requires aiohttp at least 1.1.0 and gives `yarl.URL` instances to `aiohttp.Client`.

https://github.com/KeepSafe/aiohttp/releases/tag/v1.1.0