### PR TITLE
Fix remaining warnings in tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: python
 
 matrix:
     include:
-        - python: 3.4
+        - python: 3.4.5
           env: TOXENV=py34
         - python: 3.5
           env: TOXENV=py35

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,28 @@
+import asyncio
+
 import pytest
+import aiohttp
 
 
 @pytest.fixture(scope="session", params=[True, False],
                 ids=['debug:true', 'debug:false'])
 def debug(request):
     return request.param
+
+
+@pytest.fixture
+def loop(event_loop, debug):
+    event_loop.set_debug(debug)
+    return event_loop
+
+
+@pytest.yield_fixture
+def session(loop):
+
+    @asyncio.coroutine
+    def create_session(loop):
+        return aiohttp.ClientSession(loop=loop)
+
+    session = loop.run_until_complete(create_session(loop))
+    yield session
+    loop.run_until_complete(session.close())

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,7 +16,7 @@ def loop(event_loop, debug):
     return event_loop
 
 
-@pytest.yield_fixture
+@pytest.fixture
 def session(loop):
 
     @asyncio.coroutine


### PR DESCRIPTION
So here couple improvements:
1) `ClientSession` used for http requests, since `aiohttp.request` will be deprecated soon.
2) Added `loop` fixture, alias to `event_loop`, with debug settings, as result our tests executed in both loop modes (this is alternative to setting PYTHONASYNCIODEBUG env var). 

Sorry for renaming but by convention in asyncio world, event loop usually named as `loop`, this is true for asyncio code base as well for any other aio-libs library. Not sure why py-test plugin name it `event_loop`...

should fix #7 